### PR TITLE
Add hyperlinked crossrefs to PDF output

### DIFF
--- a/sisyphus.tex
+++ b/sisyphus.tex
@@ -14,6 +14,15 @@
 \usepackage[intlimits]{amsmath}      % Good math stuff
 \usepackage{epsfig}
 \usepackage{url}
+
+% Add hyperlinks crossrefs inside pdf book (e.g. table of contents,
+% refs to figures and equations)
+\usepackage[pdftex,unicode,colorlinks, citecolor=blue,%
+filecolor=black, linkcolor=blue, urlcolor=black]{hyperref} 
+% The ref to the figure and table will point to the top of the figure
+% (not to the caption)
+
+\usepackage[figure,table]{hypcap} 
 \usepackage{makeidx}
 \usepackage{multirow}
 \usepackage{fancyvrb}


### PR DESCRIPTION
Add hyperlinks crossrefs inside pdf book (e.g. table of contents, refs to figures and equations, etc.) 
Improves usability for on-screen reading without any serious drawback for printed copy.
